### PR TITLE
Release 0.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.8
+  - 1.13
 
 before_script:
   - wget https://releases.hashicorp.com/consul/1.4.0/consul_1.4.0_linux_amd64.zip
@@ -19,7 +19,7 @@ deploy:
   provider: script
   script: make release
   on:
-    condition: '"${TRAVIS_GO_VERSION}" == "1.8"' 
+    condition: '"${TRAVIS_GO_VERSION}" == "1.13"' 
     tags: true
 
 env:

--- a/src/config_resolver_test.go
+++ b/src/config_resolver_test.go
@@ -213,7 +213,7 @@ func TestTemplateRawBytes_timeWithFormat(t *testing.T) {
 	assert.Nil(templatedByteArr)
 	assert.NotNil(err)
 	assert.Equal(`template: `+templateName+`:1:10: executing "`+templateName+
-		`" at <timeWithFormat "qwer...>: error calling timeWithFormat: strconv.ParseInt: parsing "qwerty": invalid syntax`, err.Error())
+		`" at <timeWithFormat "qwerty" "2006">: error calling timeWithFormat: strconv.ParseInt: parsing "qwerty": invalid syntax`, err.Error())
 }
 
 func TestTemplateRawBytes_systemEnv(t *testing.T) {
@@ -235,7 +235,7 @@ func TestTemplateRawBytes_systemEnv(t *testing.T) {
 	assert.Nil(templatedByteArr)
 	assert.Equal(
 		`template: `+templateName+`:1:10: executing "`+templateName+
-			`" at <systemEnv "DOESNT_EX...>: error calling systemEnv: environment variable DOESNT_EXIST not set`,
+			`" at <systemEnv "DOESNT_EXIST">: error calling systemEnv: environment variable DOESNT_EXIST not set`,
 		err.Error())
 }
 
@@ -272,7 +272,7 @@ func TestTemplateRawBytes_base64File(t *testing.T) {
 	assert.Nil(templatedByteArr)
 	assert.Equal(
 		`template: `+templateName+`:1:10: executing "`+templateName+
-			`" at <base64File "/tmp/doe...>: error calling base64File: open /tmp/doesnt/exist: no such file or directory`,
+			`" at <base64File "/tmp/doesnt/exist">: error calling base64File: open /tmp/doesnt/exist: no such file or directory`,
 		err.Error())
 }
 

--- a/src/emr_cluster.go
+++ b/src/emr_cluster.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"math/rand"
 	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -368,7 +367,7 @@ func (ec EmrCluster) GetBootstrapActions() []*emr.BootstrapActionConfig {
 			}
 
 			emrBootstrapAction := emr.BootstrapActionConfig{
-				Name: aws.String(bootstrapAction.Name),
+				Name:                  aws.String(bootstrapAction.Name),
 				ScriptBootstrapAction: &emrScriptBootstrapAction,
 			}
 
@@ -411,22 +410,14 @@ func (ec EmrCluster) GetApplications() ([]*emr.Application, error) {
 	applications := ec.Config.Applications
 
 	var emrApplicationArr []*emr.Application
-	allowedApps := []string{"Hadoop", "Hive", "Mahout", "Pig", "Spark"}
-
 	if applications != nil && len(applications) > 0 {
 		emrApplicationArr = make([]*emr.Application, len(applications))
 
 		for i, application := range applications {
-			if StringInSlice(application, allowedApps) {
-				emrApplication := emr.Application{
-					Name: aws.String(application),
-				}
-
-				emrApplicationArr[i] = &emrApplication
-			} else {
-				return nil, errors.New("Only " + strings.Join(allowedApps, ", ") +
-					" are allowed applications")
+			emrApplication := emr.Application{
+				Name: aws.String(application),
 			}
+			emrApplicationArr[i] = &emrApplication
 		}
 	}
 

--- a/src/emr_cluster_test.go
+++ b/src/emr_cluster_test.go
@@ -469,13 +469,6 @@ func TestGetApplications_WithApps(t *testing.T) {
 	assert.Len(apps, 2)
 	assert.Equal(aws.String("Hadoop"), apps[0].Name)
 	assert.Equal(aws.String("Spark"), apps[1].Name)
-
-	// fails is the app is not allowed
-	record.Applications = []string{"Snowplow"}
-	ec, _ = InitEmrCluster(*record)
-	_, err := ec.GetApplications()
-	assert.NotNil(err)
-	assert.Equal("Only Hadoop, Hive, Mahout, Pig, Spark are allowed applications", err.Error())
 }
 
 func TestGetLocation_Fail(t *testing.T) {

--- a/src/lock_test.go
+++ b/src/lock_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/main.go
+++ b/src/main.go
@@ -341,7 +341,7 @@ func getConsulFlag() cli.StringFlag {
 func up(emrConfig string, vars string) (string, error) {
 	clusterRecord, err := parseClusterRecord(emrConfig, vars)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return upWithConfig(clusterRecord)


### PR DESCRIPTION
* Update consul testutil dependency #57 
* Return error when cluster config is unparseable #58 
* Update list of allowed emr applications #59 
* Update go version #61 

This change was required to let us run flink applications on EMR using dataflow-runner.