### PR TITLE
Support default AWS Credentials chain

### DIFF
--- a/src/emr_cluster.go
+++ b/src/emr_cluster.go
@@ -45,7 +45,7 @@ func InitEmrCluster(clusterConfig ClusterConfig) (*EmrCluster, error) {
 		return nil, err
 	}
 
-	svc := emr.New(session.New(), &aws.Config{
+	svc := emr.New(session.Must(session.NewSession()), &aws.Config{
 		Region:      aws.String(clusterConfig.Region),
 		Credentials: creds,
 	})

--- a/src/job_flow_steps.go
+++ b/src/job_flow_steps.go
@@ -43,7 +43,7 @@ func InitJobFlowSteps(playbookConfig PlaybookConfig, jobflowID string, isAsync b
 		return nil, err
 	}
 
-	emrSvc := emr.New(session.New(), &aws.Config{
+	emrSvc := emr.New(session.Must(session.NewSession()), &aws.Config{
 		Region:      aws.String(playbookConfig.Region),
 		Credentials: creds,
 	})

--- a/src/lock_test.go
+++ b/src/lock_test.go
@@ -25,13 +25,14 @@ import (
 )
 
 func makeClient(t *testing.T) (*api.Client, *testutil.TestServer) {
-	// Make client config
-	conf := api.DefaultConfig()
 	// Create server
-	server, err := testutil.NewTestServerConfigT(t, nil)
+	server, err := testutil.NewTestServerT(t)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Make client config
+	conf := api.DefaultConfig()
 	conf.Address = server.HTTPAddr
 
 	// Create client

--- a/src/logs_downloader.go
+++ b/src/logs_downloader.go
@@ -46,12 +46,14 @@ func InitLogsDownloader(accessKeyID, secretAccessKey, region, jobflowID string) 
 		return nil, err
 	}
 
-	emrSvc := emr.New(session.New(), &aws.Config{
+	sess := session.Must(session.NewSession())
+
+	emrSvc := emr.New(sess, &aws.Config{
 		Region:      aws.String(region),
 		Credentials: creds,
 	})
 
-	s3Svc := s3.New(session.New(), &aws.Config{
+	s3Svc := s3.New(sess, &aws.Config{
 		Region:      aws.String(region),
 		Credentials: creds,
 	})

--- a/src/utils_test.go
+++ b/src/utils_test.go
@@ -38,11 +38,20 @@ func TestGetCredentialsProvider(t *testing.T) {
 	assert.NotNil(err)
 	assert.Equal("access-key and secret-key must both be set to 'env', or neither", err.Error())
 
+	res, err = GetCredentialsProvider("default", "faulty")
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.Equal("access-key and secret-key must both be set to 'default', or neither", err.Error())
+
 	res, err = GetCredentialsProvider("iam", "iam")
 	assert.NotNil(res)
 	assert.Nil(err)
 
 	res, err = GetCredentialsProvider("env", "env")
+	assert.NotNil(res)
+	assert.Nil(err)
+
+	res, err = GetCredentialsProvider("default", "default")
 	assert.NotNil(res)
 	assert.Nil(err)
 

--- a/vagrant/up.bash
+++ b/vagrant/up.bash
@@ -13,7 +13,7 @@ apt-get install -y language-pack-en git unzip libyaml-dev python3-pip python-yam
 echo "==============="
 echo "INSTALLING PERU"
 echo "---------------"
-sudo pip3 install peru
+sudo pip3 install 'peru==1.1.4'
 
 echo "======================================="
 echo "CLONING ANSIBLE AND PLAYBOOKS WITH PERU"

--- a/vagrant/up.playbooks
+++ b/vagrant/up.playbooks
@@ -1,3 +1,3 @@
-oss-playbooks/golang-1.8.yml
+oss-playbooks/golang-1.13.5.yml
 oss-playbooks/consul-0.8.3.yml
 oss-playbooks/wine.yml


### PR DESCRIPTION
This PR addresses this issue to provide functionality to support the default AWS Credentials chain https://github.com/snowplow/dataflow-runner/issues/36

* Tests were added to increase coverage of the new functionality

* I have successfully tested this in my AWS account, with the snowflake-transformer / snowflake-loader as detailed in these docs https://github.com/snowplow-incubator/snowplow-snowflake-loader/wiki/Setup-Guide

* Both the `cluster.json` and the `playbook.json` config files now support using the value `"default"` 
e.g.
```json
       "credentials":{
          "accessKeyId":"default",
          "secretAccessKey":"default"
       }
```

* The previous functionality is still supported, i.e. providing one of `"env"`, `"iam"` or static credentials (although I personally think this is redundant at best, and not great security practices at worst). Compatibility is important


------------
As part of setting up the dev / build environment I also had to address these issues with the set up https://github.com/snowplow/dataflow-runner/issues/62 

So those fixes are also included in this PR or submitted as PRs to the ansible-playbooks repo:
* https://github.com/snowplow/ansible-playbooks/pull/135
* https://github.com/snowplow/ansible-playbooks/pull/136


@chuwy I would really appreciate review and feedback