### PR TITLE
Log EMR cluster StateChangeReason on transient mode failure

### DIFF
--- a/src/emr_cluster.go
+++ b/src/emr_cluster.go
@@ -182,6 +182,20 @@ func clusterStateChangeReason(status *types.ClusterStatus) (string, string) {
 	return code, msg
 }
 
+// fetchStateChangeReason describes the cluster and returns its StateChangeReason code and message.
+// It returns a non-nil error if the cluster cannot be described, or empty strings if no reason is set.
+func (ec EmrCluster) fetchStateChangeReason(ctx context.Context, jobflowID string) (string, string, error) {
+	resp, err := ec.Svc.DescribeCluster(ctx, &emr.DescribeClusterInput{ClusterId: aws.String(jobflowID)})
+	if err != nil {
+		return "", "", err
+	}
+	if resp.Cluster == nil || resp.Cluster.Status == nil {
+		return "", "", nil
+	}
+	code, message := clusterStateChangeReason(resp.Cluster.Status)
+	return code, message, nil
+}
+
 // waitForClusterReady waits for the cluster to reach RUNNING or WAITING state using SDK v2 waiter.
 // Returns the cluster status even on failure (needed for bootstrap failure detection).
 func (ec EmrCluster) waitForClusterReady(ctx context.Context, jobflowID string) (*types.ClusterStatus, error) {

--- a/src/emr_cluster_test.go
+++ b/src/emr_cluster_test.go
@@ -228,6 +228,29 @@ func TestRunJobFlow_Success(t *testing.T) {
 	assert.Equal(t, "j-WAITING", id)
 }
 
+func TestFetchStateChangeReason(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	record, _ := CR.ParseClusterRecord([]byte(ClusterRecord1), nil, "")
+	ec := mockEmrCluster(*record)
+
+	// A cluster with a StateChangeReason returns its code and message
+	code, message, err := ec.fetchStateChangeReason(ctx, "j-TERMINATED_WITH_ERRORS")
+	assert.Nil(err)
+	assert.Equal("VALIDATION_ERROR", code)
+	assert.Equal("On the master instance, application provisioning failed", message)
+
+	// A cluster with no StateChangeReason returns empty strings and no error
+	code, message, err = ec.fetchStateChangeReason(ctx, "j-STARTING")
+	assert.Nil(err)
+	assert.Equal("", code)
+	assert.Equal("", message)
+
+	// A DescribeCluster failure is returned as an error
+	_, _, err = ec.fetchStateChangeReason(ctx, "bad")
+	assert.NotNil(err)
+}
+
 func TestGetJobFlowInput_Success(t *testing.T) {
 	assert := assert.New(t)
 

--- a/src/main.go
+++ b/src/main.go
@@ -329,14 +329,12 @@ func main() {
 				if err != nil {
 					// The terminated waiter only returns a generic "transitioned to Failure" error, so
 					// re-describe the cluster to recover and surface the underlying StateChangeReason.
-					if desc, derr := emrCluster.Svc.DescribeCluster(context.Background(),
-						&emr.DescribeClusterInput{ClusterId: aws.String(jobFlowSteps.JobflowID)}); derr == nil &&
-						desc.Cluster != nil && desc.Cluster.Status != nil {
-						if code, message := clusterStateChangeReason(desc.Cluster.Status); code != "" || message != "" {
-							log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
-							err = fmt.Errorf("EMR cluster %s terminated with errors: code=%s message=%q",
-								jobFlowSteps.JobflowID, code, message)
-						}
+					if code, message, derr := emrCluster.fetchStateChangeReason(context.Background(), jobFlowSteps.JobflowID); derr != nil {
+						log.Warnf("could not re-describe cluster to get StateChangeReason: %v", derr)
+					} else if code != "" || message != "" {
+						log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
+						err = fmt.Errorf("EMR cluster %s terminated with errors: code=%s message=%q",
+							jobFlowSteps.JobflowID, code, message)
 					}
 					if lock != nil && softLock != "" {
 						lock.Unlock()

--- a/src/main.go
+++ b/src/main.go
@@ -327,6 +327,17 @@ func main() {
 					maxClusterWaitDuration,
 				)
 				if err != nil {
+					// The terminated waiter only returns a generic "transitioned to Failure" error, so
+					// re-describe the cluster to recover and surface the underlying StateChangeReason.
+					if desc, derr := emrCluster.Svc.DescribeCluster(context.Background(),
+						&emr.DescribeClusterInput{ClusterId: aws.String(jobFlowSteps.JobflowID)}); derr == nil &&
+						desc.Cluster != nil && desc.Cluster.Status != nil {
+						if code, message := clusterStateChangeReason(desc.Cluster.Status); code != "" || message != "" {
+							log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
+							err = fmt.Errorf("EMR cluster %s terminated with errors: code=%s message=%q",
+								jobFlowSteps.JobflowID, code, message)
+						}
+					}
 					if lock != nil && softLock != "" {
 						lock.Unlock()
 					}


### PR DESCRIPTION
In transient mode (run-transient) the cluster is launched with its steps embedded and the runner only waits for it to terminate. When the cluster terminates with errors — provisioning, quota, IAM or networking errors, or a bootstrap failure — the ClusterTerminatedWaiter returns a generic "transitioned to Failure" error and the underlying StateChangeReason was never surfaced, leaving transient runs blind to why the cluster died.

On waiter failure, re-describe the cluster and surface Cluster.Status.StateChangeReason Code and Message both in the logs and in the returned error, mirroring the persistent path added in #98.

ref: https://snplow.atlassian.net/browse/PDP-2682