### PR TITLE
Bump Go toolchain to 1.25.11 to fix stdlib vulnerabilities

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ jobs:
     name: Release
     strategy:
       matrix:
-        go-version: [1.24.11]
+        go-version: [1.25.11]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Compile & Test
     strategy:
       matrix:
-        go-version: [1.24.11]
+        go-version: [1.25.11]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snowplow/dataflow-runner
 
-go 1.24.11
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
@@ -60,7 +60,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/snowplow-devops/go-retry v0.0.0-20210106090855-8989bbdbae1c
-	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
-golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
## What

`govulncheck` flagged **12 vulnerabilities affecting the code**, all in the **Go standard library** (`crypto/tls`, `crypto/x509`, `net`, `net/http`, `net/url`, `net/textproto`, `os`) reachable transitively via the AWS SDK, Consul and Sentry deps. None are in third-party module code we call — all are fixed by upgrading the Go toolchain.

## Changes

- CI/CD `go-version` `1.24.11` → `1.25.11` (this is what produces the released binary, so it's the actual fix)
- `go.mod` `go` directive `1.24.11` → `1.25.11`
- `golang.org/x/sys` `0.40.0` → `0.44.0` — clears the one remaining module-level advisory (`GO-2026-5024`, not called by our code)

## Verification

- `govulncheck ./build/src/...` → **No vulnerabilities found** (was 12 affecting)
- Cross-builds (linux/darwin/windows) succeed via `make`
- `make test` passes — 75.2% coverage