### PR TITLE
Retry bootstrap failures in transient mode

### DIFF
--- a/src/emr_cluster.go
+++ b/src/emr_cluster.go
@@ -30,9 +30,27 @@ import (
 )
 
 const (
-	invalidStateSleepSeconds     = 30
+	// clusterPollInterval is how often the SDK waiters re-describe a cluster while
+	// waiting for it to reach a state. Shared by every cluster wait on both the
+	// persistent and transient paths.
+	clusterPollInterval = 30 * time.Second
+	// clusterWaitMaxDuration is the maximum time to wait for a cluster to launch,
+	// and for a cluster we have asked to terminate to do so.
+	clusterWaitMaxDuration = 60 * time.Minute
+	// transientMaxWaitDuration is the maximum time to wait for a transient run's
+	// steps to finish and its cluster to terminate. It dwarfs
+	// clusterWaitMaxDuration because it is bounded by how long the job runs, not
+	// by how long provisioning should take.
+	transientMaxWaitDuration = 14 * 24 * time.Hour
+
+	// bootstrapRetryAttempts is the total number of times a cluster is launched
+	// before giving up on a bootstrap failure, counting the first launch.
+	bootstrapRetryAttempts = 3
+
+	// bootstrapFailureSleepSeconds bounds the random pause between `up`'s
+	// bootstrap-failure retries. Held in seconds rather than as a Duration
+	// because it is passed to rand.Intn.
 	bootstrapFailureSleepSeconds = 300
-	clusterWaitMaxDuration       = 60 * time.Minute
 )
 
 // EMRAPI defines the interface for EMR operations (for mocking in tests)
@@ -114,7 +132,7 @@ func (ec EmrCluster) runJobFlow(ctx context.Context, sleepTime int) (string, err
 	}
 
 	var done = false
-	var retryCount = 3
+	var retryCount = bootstrapRetryAttempts
 	var clusterState string
 	var jobflowID string
 	var reasonCode, reasonMessage string
@@ -140,8 +158,7 @@ func (ec EmrCluster) runJobFlow(ctx context.Context, sleepTime int) (string, err
 			log.Errorf("EMR cluster state change reason: code='%s' message=%q", reasonCode, reasonMessage)
 		}
 
-		if clusterStatus.StateChangeReason != nil &&
-			clusterStatus.StateChangeReason.Code == types.ClusterStateChangeReasonCodeBootstrapFailure {
+		if isBootstrapFailure(clusterStatus) {
 
 			retryCount--
 
@@ -182,6 +199,16 @@ func clusterStateChangeReason(status *types.ClusterStatus) (string, string) {
 	return code, msg
 }
 
+// isBootstrapFailure reports whether a cluster status indicates the cluster
+// terminated because a bootstrap action failed. This is the only termination
+// reason for which relaunching with the same steps attached is safe: bootstrap
+// actions run before any step, so no step can have run.
+func isBootstrapFailure(status *types.ClusterStatus) bool {
+	return status != nil &&
+		status.StateChangeReason != nil &&
+		status.StateChangeReason.Code == types.ClusterStateChangeReasonCodeBootstrapFailure
+}
+
 // fetchStateChangeReason describes the cluster and returns its StateChangeReason code and message.
 // It returns a non-nil error if the cluster cannot be described, or empty strings if no reason is set.
 func (ec EmrCluster) fetchStateChangeReason(ctx context.Context, jobflowID string) (string, string, error) {
@@ -220,8 +247,8 @@ func (ec EmrCluster) waitForClusterReady(ctx context.Context, jobflowID string) 
 	}
 
 	waiter := emr.NewClusterRunningWaiter(ec.Svc, func(o *emr.ClusterRunningWaiterOptions) {
-		o.MinDelay = invalidStateSleepSeconds * time.Second
-		o.MaxDelay = invalidStateSleepSeconds * time.Second
+		o.MinDelay = clusterPollInterval
+		o.MaxDelay = clusterPollInterval
 	})
 
 	waiterErr := waiter.Wait(ctx, input, clusterWaitMaxDuration)
@@ -259,11 +286,59 @@ func (ec EmrCluster) waitForClusterTerminated(ctx context.Context, jobflowID str
 	}
 
 	waiter := emr.NewClusterTerminatedWaiter(ec.Svc, func(o *emr.ClusterTerminatedWaiterOptions) {
-		o.MinDelay = invalidStateSleepSeconds * time.Second
-		o.MaxDelay = invalidStateSleepSeconds * time.Second
+		o.MinDelay = clusterPollInterval
+		o.MaxDelay = clusterPollInterval
 	})
 
 	return waiter.Wait(ctx, input, clusterWaitMaxDuration)
+}
+
+// waitForClusterFinished waits for a transient cluster to finish its steps and
+// terminate, returning the final cluster status so the caller can classify the
+// outcome.
+//
+// It is separate from waitForClusterTerminated, which serves `down`: there the
+// cluster was asked to terminate and terminating with errors is still success.
+// Here TERMINATED_WITH_ERRORS means the run itself failed.
+func (ec EmrCluster) waitForClusterFinished(ctx context.Context, jobflowID string) (*types.ClusterStatus, error) {
+	input := &emr.DescribeClusterInput{ClusterId: aws.String(jobflowID)}
+
+	resp, err := retry.ExponentialWithInterface(3, time.Second, "emr.DescribeCluster", func() (any, error) {
+		return ec.Svc.DescribeCluster(ctx, input)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve immediately if the cluster is already in a terminal state
+	output := resp.(*emr.DescribeClusterOutput)
+	status := output.Cluster.Status
+	switch status.State {
+	case types.ClusterStateTerminated:
+		return status, nil
+	case types.ClusterStateTerminatedWithErrors:
+		return status, fmt.Errorf("EMR cluster %s terminated with errors", jobflowID)
+	}
+
+	waiter := emr.NewClusterTerminatedWaiter(ec.Svc, func(o *emr.ClusterTerminatedWaiterOptions) {
+		o.MinDelay = clusterPollInterval
+		o.MaxDelay = clusterPollInterval
+	})
+
+	waiterErr := waiter.Wait(ctx, input, transientMaxWaitDuration)
+
+	// Re-describe so the caller can classify the outcome; the waiter's own error
+	// says only that it transitioned to a failure state.
+	resp, err = ec.Svc.DescribeCluster(ctx, input)
+	if err != nil {
+		if waiterErr != nil {
+			return nil, waiterErr
+		}
+		return nil, err
+	}
+
+	output = resp.(*emr.DescribeClusterOutput)
+	return output.Cluster.Status, waiterErr
 }
 
 // --- Parameter builders

--- a/src/emr_cluster_test.go
+++ b/src/emr_cluster_test.go
@@ -122,6 +122,61 @@ func mockEmrCluster(clusterRecord ClusterConfig) *EmrCluster {
 	}
 }
 
+// mockEMRAPISequence returns a scripted sequence of cluster states on successive
+// DescribeCluster calls, enabling tests of the waiter path without sleeping.
+type mockEMRAPISequence struct {
+	sequence []types.ClusterState
+	callNum  int
+}
+
+func (m *mockEMRAPISequence) DescribeCluster(ctx context.Context, input *emr.DescribeClusterInput, optFns ...func(*emr.Options)) (*emr.DescribeClusterOutput, error) {
+	if m.callNum >= len(m.sequence) {
+		return nil, errors.New("DescribeCluster sequence exhausted")
+	}
+	state := m.sequence[m.callNum]
+	m.callNum++
+
+	// Build the status based on the state
+	status := &types.ClusterStatus{State: state}
+	if state == types.ClusterStateTerminated {
+		status.StateChangeReason = &types.ClusterStateChangeReason{
+			Code:    types.ClusterStateChangeReasonCodeBootstrapFailure,
+			Message: aws.String("Bootstrap action returned a non-zero return code"),
+		}
+	} else if state == types.ClusterStateTerminatedWithErrors {
+		status.StateChangeReason = &types.ClusterStateChangeReason{
+			Code:    types.ClusterStateChangeReasonCodeValidationError,
+			Message: aws.String("On the master instance, application provisioning failed"),
+		}
+	}
+
+	return &emr.DescribeClusterOutput{
+		Cluster: &types.Cluster{
+			Status: status,
+		},
+	}, nil
+}
+
+func (m *mockEMRAPISequence) RunJobFlow(ctx context.Context, input *emr.RunJobFlowInput, optFns ...func(*emr.Options)) (*emr.RunJobFlowOutput, error) {
+	return nil, errors.New("RunJobFlow not supported by mockEMRAPISequence")
+}
+
+func (m *mockEMRAPISequence) TerminateJobFlows(ctx context.Context, input *emr.TerminateJobFlowsInput, optFns ...func(*emr.Options)) (*emr.TerminateJobFlowsOutput, error) {
+	return nil, errors.New("TerminateJobFlows not supported by mockEMRAPISequence")
+}
+
+func (m *mockEMRAPISequence) AddJobFlowSteps(ctx context.Context, input *emr.AddJobFlowStepsInput, optFns ...func(*emr.Options)) (*emr.AddJobFlowStepsOutput, error) {
+	return nil, errors.New("AddJobFlowSteps not supported by mockEMRAPISequence")
+}
+
+func (m *mockEMRAPISequence) ListSteps(ctx context.Context, input *emr.ListStepsInput, optFns ...func(*emr.Options)) (*emr.ListStepsOutput, error) {
+	return nil, errors.New("ListSteps not supported by mockEMRAPISequence")
+}
+
+func (m *mockEMRAPISequence) DescribeStep(ctx context.Context, input *emr.DescribeStepInput, optFns ...func(*emr.Options)) (*emr.DescribeStepOutput, error) {
+	return nil, errors.New("DescribeStep not supported by mockEMRAPISequence")
+}
+
 var CR, _ = InitConfigResolver()
 
 func TestInitEmrCluster(t *testing.T) {
@@ -560,4 +615,133 @@ func TestGetLocation_Success(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(s, "")
 	assert.Equal(p, "eu-central-1")
+}
+
+func TestIsBootstrapFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	// a nil status must not be treated as a bootstrap failure, and must not panic
+	assert.False(isBootstrapFailure(nil))
+
+	// a status with no reason at all
+	assert.False(isBootstrapFailure(&types.ClusterStatus{
+		State: types.ClusterStateTerminatedWithErrors,
+	}))
+
+	// a different reason code
+	assert.False(isBootstrapFailure(&types.ClusterStatus{
+		State: types.ClusterStateTerminatedWithErrors,
+		StateChangeReason: &types.ClusterStateChangeReason{
+			Code: types.ClusterStateChangeReasonCodeValidationError,
+		},
+	}))
+
+	assert.True(isBootstrapFailure(&types.ClusterStatus{
+		State: types.ClusterStateTerminatedWithErrors,
+		StateChangeReason: &types.ClusterStateChangeReason{
+			Code: types.ClusterStateChangeReasonCodeBootstrapFailure,
+		},
+	}))
+}
+
+func TestWaitForClusterFinished(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	record, _ := CR.ParseClusterRecord([]byte(ClusterRecord1), nil, "")
+	ec := mockEmrCluster(*record)
+
+	// a cleanly terminated cluster succeeds and hands back its status
+	status, err := ec.waitForClusterFinished(ctx, "j-TERMINATED")
+	assert.Nil(err)
+	assert.NotNil(status)
+	assert.Equal(types.ClusterStateTerminated, status.State)
+
+	// TERMINATED_WITH_ERRORS is a failure here, unlike in waitForClusterTerminated,
+	// and the status still comes back so the caller can classify it
+	status, err = ec.waitForClusterFinished(ctx, "j-TERMINATED_WITH_ERRORS")
+	assert.NotNil(err)
+	assert.NotNil(status)
+	assert.Equal(types.ClusterStateTerminatedWithErrors, status.State)
+	assert.Equal(types.ClusterStateChangeReasonCodeValidationError, status.StateChangeReason.Code)
+
+	// an undescribable cluster yields no status at all
+	status, err = ec.waitForClusterFinished(ctx, "nope")
+	assert.NotNil(err)
+	assert.Nil(status)
+}
+
+// TestWaitForClusterReady_WithWaiter tests the waiter path when the cluster
+// is not yet in a ready state, ensuring the waiter construction and post-wait
+// re-describe are exercised without sleeping.
+func TestWaitForClusterReady_WithWaiter(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	record, _ := CR.ParseClusterRecord([]byte(ClusterRecord1), nil, "")
+
+	ec := &EmrCluster{
+		Config: *record,
+		Svc: &mockEMRAPISequence{
+			sequence: []types.ClusterState{
+				types.ClusterStateStarting,
+				types.ClusterStateRunning,
+				types.ClusterStateRunning,
+			},
+		},
+	}
+
+	status, err := ec.waitForClusterReady(ctx, "j-test")
+	assert.Nil(err)
+	assert.NotNil(status)
+	assert.Equal(types.ClusterStateRunning, status.State)
+}
+
+// TestWaitForClusterFinished_WithWaiter_Success tests the waiter path when the
+// cluster is running and then terminates cleanly, ensuring waiter construction,
+// waiter.Wait, and post-wait re-describe are exercised without sleeping.
+func TestWaitForClusterFinished_WithWaiter_Success(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	record, _ := CR.ParseClusterRecord([]byte(ClusterRecord1), nil, "")
+
+	ec := &EmrCluster{
+		Config: *record,
+		Svc: &mockEMRAPISequence{
+			sequence: []types.ClusterState{
+				types.ClusterStateRunning,
+				types.ClusterStateTerminated,
+				types.ClusterStateTerminated,
+			},
+		},
+	}
+
+	status, err := ec.waitForClusterFinished(ctx, "j-test")
+	assert.Nil(err)
+	assert.NotNil(status)
+	assert.Equal(types.ClusterStateTerminated, status.State)
+}
+
+// TestWaitForClusterFinished_WithWaiter_Failure tests the waiter path when the
+// cluster fails during execution, ensuring the caller receives both the error
+// and the status for classification (the critical branch for transient retries).
+func TestWaitForClusterFinished_WithWaiter_Failure(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	record, _ := CR.ParseClusterRecord([]byte(ClusterRecord1), nil, "")
+
+	ec := &EmrCluster{
+		Config: *record,
+		Svc: &mockEMRAPISequence{
+			sequence: []types.ClusterState{
+				types.ClusterStateRunning,
+				types.ClusterStateTerminatedWithErrors,
+				types.ClusterStateTerminatedWithErrors,
+			},
+		},
+	}
+
+	status, err := ec.waitForClusterFinished(ctx, "j-test")
+	assert.NotNil(err)
+	assert.NotNil(status)
+	assert.Equal(types.ClusterStateTerminatedWithErrors, status.State)
+	assert.Equal(types.ClusterStateChangeReasonCodeValidationError, status.StateChangeReason.Code)
 }

--- a/src/job_flow_steps.go
+++ b/src/job_flow_steps.go
@@ -199,6 +199,33 @@ func (jfs JobFlowSteps) GetStepIDsWithContext(ctx context.Context) ([]string, er
 	return stepIDs, nil
 }
 
+// FailedStepIDs returns the IDs of steps that have already failed, without
+// waiting for any that have not finished.
+//
+// Unlike GetFailedStepIDs it never blocks: that method waits for every step to
+// reach COMPLETED, FAILED or CANCELLED, and a step left in any other state — for
+// instance INTERRUPTED, which is what EMR reports when a cluster dies mid-step —
+// makes it wait indefinitely. This is the safe form to use once the cluster is
+// already gone.
+func (jfs JobFlowSteps) FailedStepIDs() ([]string, error) {
+	return jfs.FailedStepIDsWithContext(context.Background())
+}
+
+// FailedStepIDsWithContext is FailedStepIDs with context support
+func (jfs JobFlowSteps) FailedStepIDsWithContext(ctx context.Context) ([]string, error) {
+	stepIDs, err := jfs.GetStepIDsWithContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	_, _, failedStepIDs, _, _, err := jfs.RetrieveStepsStatesWithContext(ctx, stepIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return failedStepIDs, nil
+}
+
 // RetrieveStepsStates retrieves the states of all the steps for a job flow returning the state
 // of every step as well as information about success or failure for each one
 func (jfs JobFlowSteps) RetrieveStepsStates(stepIDs []string) (int, int, []string, []string, []string, error) {

--- a/src/job_flow_steps_test.go
+++ b/src/job_flow_steps_test.go
@@ -303,3 +303,83 @@ func TestRetrieveStepState_Fail(t *testing.T) {
 	assert.NotNil(err)
 	assert.Equal("Couldn't retrieve step step-id state: emr.DescribeStep: DescribeStep failed", err.Error())
 }
+
+// mockEMRAPIStepStates lists a fixed set of steps and reports each one's state by
+// step ID, so a mixture of terminal and non-terminal steps can be exercised.
+type mockEMRAPIStepStates struct {
+	stepIDs []string
+	states  map[string]types.StepState
+}
+
+func (m *mockEMRAPIStepStates) ListSteps(ctx context.Context, input *emr.ListStepsInput, optFns ...func(*emr.Options)) (*emr.ListStepsOutput, error) {
+	if !strings.HasPrefix(*input.ClusterId, "j-") {
+		return nil, errors.New("ListSteps failed")
+	}
+	steps := make([]types.StepSummary, 0, len(m.stepIDs))
+	for _, id := range m.stepIDs {
+		steps = append(steps, types.StepSummary{Id: aws.String(id)})
+	}
+	return &emr.ListStepsOutput{Steps: steps}, nil
+}
+
+func (m *mockEMRAPIStepStates) DescribeStep(ctx context.Context, input *emr.DescribeStepInput, optFns ...func(*emr.Options)) (*emr.DescribeStepOutput, error) {
+	testTime := time.Date(2019, time.October, 10, 23, 0, 0, 0, time.UTC)
+	return &emr.DescribeStepOutput{
+		Step: &types.Step{
+			Name: aws.String("step"),
+			Id:   input.StepId,
+			Status: &types.StepStatus{
+				State: m.states[*input.StepId],
+				Timeline: &types.StepTimeline{
+					StartDateTime: &testTime,
+					EndDateTime:   &testTime,
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *mockEMRAPIStepStates) RunJobFlow(ctx context.Context, input *emr.RunJobFlowInput, optFns ...func(*emr.Options)) (*emr.RunJobFlowOutput, error) {
+	return nil, nil
+}
+
+func (m *mockEMRAPIStepStates) TerminateJobFlows(ctx context.Context, input *emr.TerminateJobFlowsInput, optFns ...func(*emr.Options)) (*emr.TerminateJobFlowsOutput, error) {
+	return nil, nil
+}
+
+func (m *mockEMRAPIStepStates) DescribeCluster(ctx context.Context, input *emr.DescribeClusterInput, optFns ...func(*emr.Options)) (*emr.DescribeClusterOutput, error) {
+	return nil, nil
+}
+
+func (m *mockEMRAPIStepStates) AddJobFlowSteps(ctx context.Context, input *emr.AddJobFlowStepsInput, optFns ...func(*emr.Options)) (*emr.AddJobFlowStepsOutput, error) {
+	return nil, nil
+}
+
+func TestFailedStepIDs(t *testing.T) {
+	assert := assert.New(t)
+	record, _ := CR.ParsePlaybookRecord([]byte(PlaybookRecord1), nil, "")
+
+	// One step failed, one completed, and one is INTERRUPTED — which
+	// GetFailedStepIDs would wait on forever, since it counts INTERRUPTED as
+	// neither success nor failure. FailedStepIDs must return in a single pass
+	// with just the failed step.
+	svc := &mockEMRAPIStepStates{
+		stepIDs: []string{"s-DONE", "s-FAIL", "s-STUCK"},
+		states: map[string]types.StepState{
+			"s-DONE":  types.StepStateCompleted,
+			"s-FAIL":  types.StepStateFailed,
+			"s-STUCK": types.StepStateInterrupted,
+		},
+	}
+	jfs := &JobFlowSteps{Config: *record, JobflowID: "j-123", IsBlocking: true, EmrSvc: svc}
+
+	failedStepIDs, err := jfs.FailedStepIDs()
+	assert.Nil(err)
+	assert.Equal([]string{"s-FAIL"}, failedStepIDs)
+
+	// an undescribable cluster surfaces the error rather than an empty list
+	jfs = &JobFlowSteps{Config: *record, JobflowID: "nope", IsBlocking: true, EmrSvc: svc}
+	failedStepIDs, err = jfs.FailedStepIDs()
+	assert.NotNil(err)
+	assert.Nil(failedStepIDs)
+}

--- a/src/main.go
+++ b/src/main.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/emr"
 	"github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/urfave/cli.v1"
@@ -52,10 +50,6 @@ const (
 
 	// logRotationWaitSeconds is the time to wait for EMR log files to be rotated to S3
 	logRotationWaitSeconds = 300
-	// maxClusterWaitDuration is the maximum time to wait for a cluster to terminate (14 days)
-	maxClusterWaitDuration = 14 * 24 * time.Hour
-	// clusterPollInterval is the interval between cluster state checks
-	clusterPollInterval = 45 * time.Second
 )
 
 func main() {
@@ -293,7 +287,7 @@ func main() {
 					return exitCodeError(sentryEnabled, err)
 				}
 
-				jobFlowSteps, err := runJobFlowWithSteps(emrCluster, playbookRecord)
+				jobFlowSteps, err := InitJobFlowSteps(*playbookRecord, "", false)
 				if err != nil {
 					if lock != nil && softLock != "" {
 						lock.Unlock()
@@ -301,48 +295,13 @@ func main() {
 					return exitCodeError(sentryEnabled, err)
 				}
 
-				log.Infof("Transient EMR run with jobflow ID [%s] started successfully", jobFlowSteps.JobflowID)
-
-				log.Info("Waiting until cluster is terminated...")
-
-				// Use SDK v2 waiter for cluster termination
-				// Safe type assertion - in production this will always be *emr.Client
-				emrClient, ok := emrCluster.Svc.(*emr.Client)
-				if !ok {
-					if lock != nil && softLock != "" {
-						lock.Unlock()
-					}
-					return exitCodeError(sentryEnabled, fmt.Errorf("failed to create cluster termination waiter: EMR service is not a concrete client"))
-				}
-
-				waiter := emr.NewClusterTerminatedWaiter(emrClient, func(o *emr.ClusterTerminatedWaiterOptions) {
-					o.MinDelay = clusterPollInterval
-					o.MaxDelay = clusterPollInterval
-				})
-
-				err = waiter.Wait(context.Background(),
-					&emr.DescribeClusterInput{
-						ClusterId: aws.String(jobFlowSteps.JobflowID),
-					},
-					maxClusterWaitDuration,
-				)
+				err = runTransientJobFlow(context.Background(), emrCluster, jobFlowSteps)
 				if err != nil {
-					// The terminated waiter only returns a generic "transitioned to Failure" error, so
-					// re-describe the cluster to recover and surface the underlying StateChangeReason.
-					if code, message, derr := emrCluster.fetchStateChangeReason(context.Background(), jobFlowSteps.JobflowID); derr != nil {
-						log.Warnf("could not re-describe cluster to get StateChangeReason: %v", derr)
-					} else if code != "" || message != "" {
-						log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
-						err = fmt.Errorf("EMR cluster %s terminated with errors: code=%s message=%q",
-							jobFlowSteps.JobflowID, code, message)
-					}
 					if lock != nil && softLock != "" {
 						lock.Unlock()
 					}
 					return exitCodeError(sentryEnabled, err)
 				}
-
-				log.Infof("EMR cluster with ID [%s] is terminated successfully", jobFlowSteps.JobflowID)
 
 				failedStepIDs, err := jobFlowSteps.GetFailedStepIDs()
 
@@ -456,35 +415,6 @@ func upWithConfig(clusterRecord *ClusterConfig) (string, error) {
 	}
 
 	return jobflowID, nil
-}
-
-func runJobFlowWithSteps(emrCluster *EmrCluster, playbookRecord *PlaybookConfig) (*JobFlowSteps, error) {
-
-	jobFlowInput, err := emrCluster.GetJobFlowInput(false)
-	if err != nil {
-		return nil, err
-	}
-
-	jobFlowSteps, err := InitJobFlowSteps(*playbookRecord, "", false)
-	if err != nil {
-		return nil, err
-	}
-
-	addJobFlowStepsInput, err := jobFlowSteps.GetJobFlowStepsInput()
-	if err != nil {
-		return nil, err
-	}
-
-	jobFlowInput.Steps = addJobFlowStepsInput.Steps
-
-	jobFlowOutput, err := emrCluster.Svc.RunJobFlow(context.Background(), jobFlowInput)
-	if err != nil {
-		return nil, err
-	}
-
-	jobFlowSteps.JobflowID = *jobFlowOutput.JobFlowId
-
-	return jobFlowSteps, nil
 }
 
 // log the failed steps by printing out the different log files for each failed step

--- a/src/main.go
+++ b/src/main.go
@@ -297,6 +297,17 @@ func main() {
 
 				err = runTransientJobFlow(context.Background(), emrCluster, jobFlowSteps)
 				if err != nil {
+					// The run failed, but its steps may still have run and failed, so
+					// their logs are worth showing. FailedStepIDs is the non-blocking
+					// form: the cluster is already gone, so a step that never reached
+					// a terminal state must not be waited on. Its own error is
+					// discarded — the failure worth reporting is the one above.
+					if logFailedSteps {
+						failedStepIDs, ferr := jobFlowSteps.FailedStepIDs()
+						if ferr == nil && len(failedStepIDs) > 0 {
+							displayFailedStepsLogs(failedStepIDs, emrPlaybook, jobFlowSteps.JobflowID, vars)
+						}
+					}
 					if lock != nil && softLock != "" {
 						lock.Unlock()
 					}

--- a/src/transient.go
+++ b/src/transient.go
@@ -1,0 +1,246 @@
+//
+// Copyright (c) 2016-2026 Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/emr"
+	"github.com/aws/aws-sdk-go-v2/service/emr/types"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/snowplow-devops/go-retry"
+)
+
+const (
+	// transientBootstrapJitterSeconds bounds the random pause between attempts.
+	// There is no floor: a relaunch already takes minutes (teardown,
+	// re-provisioning, bootstrap), so the jitter serves only to stop a cohort of
+	// runners that failed on a shared dependency relaunching in lockstep. `up`
+	// uses a wider bound, bootstrapFailureSleepSeconds.
+	transientBootstrapJitterSeconds = 30
+)
+
+// launchTransientCluster launches a cluster with the playbook's steps attached and
+// returns the new jobflow ID.
+//
+// The steps go in the RunJobFlow call rather than a later AddJobFlowSteps: the
+// cluster then self-terminates once they finish, so no live cluster is left
+// behind if this process dies.
+func launchTransientCluster(ctx context.Context, ec *EmrCluster, jfs *JobFlowSteps) (string, error) {
+	jobFlowInput, err := ec.GetJobFlowInput(false)
+	if err != nil {
+		return "", err
+	}
+
+	stepsInput, err := jfs.GetJobFlowStepsInput()
+	if err != nil {
+		return "", err
+	}
+	jobFlowInput.Steps = stepsInput.Steps
+
+	resp, err := retry.ExponentialWithInterface(3, time.Second, "emr.RunJobFlow", func() (any, error) {
+		return ec.Svc.RunJobFlow(ctx, jobFlowInput)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.(*emr.RunJobFlowOutput).JobFlowId, nil
+}
+
+// clusterIsUp reports whether the cluster reached a state in which its steps can
+// run.
+func clusterIsUp(status *types.ClusterStatus) bool {
+	return status != nil &&
+		(status.State == types.ClusterStateRunning || status.State == types.ClusterStateWaiting)
+}
+
+// clusterIsTerminalish reports whether the cluster is on its way out or already
+// gone. A status that is neither this nor clusterIsUp means the cluster is still
+// coming up, which is what the launch wait returns when it times out.
+func clusterIsTerminalish(status *types.ClusterStatus) bool {
+	return status != nil &&
+		(status.State == types.ClusterStateTerminating ||
+			status.State == types.ClusterStateTerminated ||
+			status.State == types.ClusterStateTerminatedWithErrors)
+}
+
+// launchFailureError builds the error for a cluster that never reached RUNNING,
+// naming the state change reason. This is the sole owner of logging that
+// reason: callers must not log it themselves, or an attempt that is about to
+// be retried logs the same event twice.
+func launchFailureError(jobflowID string, status *types.ClusterStatus) error {
+	code, message := clusterStateChangeReason(status)
+	log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
+	return fmt.Errorf("EMR cluster %s failed to launch with state %s: code=%s message=%q",
+		jobflowID, status.State, code, message)
+}
+
+// runTransientAttempt performs one transient run: launch a cluster with the
+// playbook's steps attached, wait for it to come up, then wait for it to finish.
+//
+// The two waits are separate because a single terminate-wait conflates "the
+// cluster never came up" with "the job failed", gives the launch no bound of its
+// own, and leaves the outcome dependent on which terminal state EMR picks.
+//
+// A non-nil status is returned only when the cluster failed to come up, so the
+// caller can decide whether to retry. Past launch the status is always nil: a
+// step may have run, so re-submitting the playbook would no longer be safe.
+func runTransientAttempt(ctx context.Context, ec *EmrCluster, jfs *JobFlowSteps) (*types.ClusterStatus, error) {
+	jobflowID, err := launchTransientCluster(ctx, ec, jfs)
+	if err != nil {
+		return nil, err
+	}
+	jfs.JobflowID = jobflowID
+
+	log.Infof("Transient EMR run with jobflow ID [%s] started successfully", jobflowID)
+	log.Info("Waiting until cluster is running...")
+
+	launchStatus, launchErr := ec.waitForClusterReady(ctx, jobflowID)
+	if launchStatus == nil {
+		// The cluster could not be described at all, so the failure cannot be
+		// classified. Report it without a status: an unclassifiable failure must
+		// never be retried, because retrying re-submits the steps.
+		return nil, launchErr
+	}
+
+	if !clusterIsUp(launchStatus) {
+		if !clusterIsTerminalish(launchStatus) {
+			// The launch wait timed out while the cluster was still coming up:
+			// waitForClusterReady returns a non-terminal status alongside its
+			// error. Left alone the cluster keeps billing, and may still come up
+			// and run the steps after we have reported failure. No step can have
+			// run yet, so terminating is safe.
+			if termErr := ec.TerminateJobFlowWithContext(ctx, jobflowID); termErr != nil {
+				log.Warnf("Failed to terminate EMR cluster %s after launch timeout: %v", jobflowID, termErr)
+			}
+			if launchErr == nil {
+				// A non-terminal, non-up status is only expected alongside a
+				// launch error; never report success for a cluster that never
+				// came up.
+				launchErr = fmt.Errorf("EMR cluster %s did not come up in time (state %s)",
+					jobflowID, launchStatus.State)
+			}
+			return nil, launchErr
+		}
+
+		// The cluster is on its way out, or already gone. A status observed at
+		// TERMINATING may not carry its StateChangeReason yet, so wait for the
+		// terminal state and classify from that.
+		settled, settledErr := ec.waitForClusterFinished(ctx, jobflowID)
+		if settled != nil {
+			launchStatus = settled
+		}
+
+		// A bare terminal state is not enough to call this success: EMR reports
+		// plain TERMINATED even when the failure happened during bootstrap, so
+		// waitForClusterFinished's nil error cannot be trusted on its own.
+		code, message := clusterStateChangeReason(launchStatus)
+		switch {
+		case code == string(types.ClusterStateChangeReasonCodeAllStepsCompleted):
+			// The cluster passed through RUNNING between two polls and the run
+			// has already finished cleanly. Nothing failed.
+			log.Infof("EMR cluster with ID [%s] is terminated successfully", jobflowID)
+			return nil, nil
+		case code != "" || message != "":
+			return launchStatus, launchFailureError(jobflowID, launchStatus)
+		default:
+			// No reason ever surfaced: the failure cannot be classified, so it
+			// must never be retried.
+			if settledErr == nil {
+				settledErr = fmt.Errorf("EMR cluster %s failed to launch with state %s and no state change reason",
+					jobflowID, launchStatus.State)
+			}
+			return nil, settledErr
+		}
+	}
+
+	log.Info("Waiting until cluster is terminated...")
+
+	finalStatus, err := ec.waitForClusterFinished(ctx, jobflowID)
+	if err != nil {
+		code, message := clusterStateChangeReason(finalStatus)
+		if code != "" || message != "" {
+			log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
+			return nil, fmt.Errorf("EMR cluster %s terminated with errors: code=%s message=%q",
+				jobflowID, code, message)
+		}
+		return nil, err
+	}
+
+	// As in the settle branch above, a nil error only means the cluster reached
+	// TERMINATED: EMR reports plain TERMINATED even when a step failed. Every
+	// outcome here returns a nil status — a step may have run, so none of it is
+	// retryable.
+	code, message := clusterStateChangeReason(finalStatus)
+	switch {
+	case code == string(types.ClusterStateChangeReasonCodeAllStepsCompleted):
+		log.Infof("EMR cluster with ID [%s] is terminated successfully", jobflowID)
+		return nil, nil
+	case code != "" || message != "":
+		log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
+		return nil, fmt.Errorf("EMR cluster %s terminated with state %s: code=%s message=%q",
+			jobflowID, finalStatus.State, code, message)
+	default:
+		// No reason ever surfaced: the run cannot be confirmed complete.
+		return nil, fmt.Errorf("EMR cluster %s terminated with state %s and no state change reason, so the run cannot be confirmed complete",
+			jobflowID, finalStatus.State)
+	}
+}
+
+// runTransientJobFlow performs a transient run, relaunching from scratch when the
+// cluster fails to bootstrap.
+//
+// Only BOOTSTRAP_FAILURE is retried: bootstrap actions run before any step, so no
+// step can have run and re-submitting the playbook cannot re-process data.
+// Reasons like INTERNAL_ERROR or INSTANCE_FAILURE can strike part-way through a
+// step, so those — and any failure that cannot be classified — are never
+// retried.
+func runTransientJobFlow(ctx context.Context, ec *EmrCluster, jfs *JobFlowSteps) error {
+	return runTransientJobFlowWithJitter(ctx, ec, jfs, transientBootstrapJitterSeconds)
+}
+
+// runTransientJobFlowWithJitter is runTransientJobFlow with the jitter bound
+// injected, so tests do not have to sleep. jitterSeconds must be at least 1.
+func runTransientJobFlowWithJitter(ctx context.Context, ec *EmrCluster, jfs *JobFlowSteps, jitterSeconds int) error {
+	var code, message string
+
+	for attempt := 1; attempt <= bootstrapRetryAttempts; attempt++ {
+		launchStatus, err := runTransientAttempt(ctx, ec, jfs)
+		if !isBootstrapFailure(launchStatus) {
+			// Only a bootstrap failure is retryable. Everything else — success, a
+			// job-phase failure, a non-bootstrap launch failure, a launch that
+			// timed out, one that could not be classified — stands as it is.
+			return err
+		}
+
+		code, message = clusterStateChangeReason(launchStatus)
+
+		if attempt == bootstrapRetryAttempts {
+			break
+		}
+
+		pause := rand.Intn(jitterSeconds)
+		log.Warnf("Bootstrap failure detected on attempt %d of %d, retrying in %d seconds...",
+			attempt, bootstrapRetryAttempts, pause)
+		time.Sleep(time.Second * time.Duration(pause))
+	}
+
+	return fmt.Errorf("could not start the cluster due to bootstrap failure after %d attempts: code=%s message=%q",
+		bootstrapRetryAttempts, code, message)
+}

--- a/src/transient.go
+++ b/src/transient.go
@@ -80,14 +80,18 @@ func clusterIsTerminalish(status *types.ClusterStatus) bool {
 			status.State == types.ClusterStateTerminatedWithErrors)
 }
 
-// launchFailureError builds the error for a cluster that never reached RUNNING,
-// naming the state change reason. This is the sole owner of logging that
-// reason: callers must not log it themselves, or an attempt that is about to
-// be retried logs the same event twice.
-func launchFailureError(jobflowID string, status *types.ClusterStatus) error {
+// clusterFailureError builds the error for a cluster the launch wait saw
+// terminate, naming the state change reason. It avoids claiming the cluster
+// failed to launch: a short job can pass through RUNNING between two polls, so
+// this is also reached for a run whose steps ran and failed.
+//
+// This is the sole owner of logging that reason: callers must not log it
+// themselves, or an attempt that is about to be retried logs the same event
+// twice.
+func clusterFailureError(jobflowID string, status *types.ClusterStatus) error {
 	code, message := clusterStateChangeReason(status)
 	log.Errorf("EMR cluster state change reason: code='%s' message=%q", code, message)
-	return fmt.Errorf("EMR cluster %s failed to launch with state %s: code=%s message=%q",
+	return fmt.Errorf("EMR cluster %s failed with state %s: code=%s message=%q",
 		jobflowID, status.State, code, message)
 }
 
@@ -150,6 +154,11 @@ func runTransientAttempt(ctx context.Context, ec *EmrCluster, jfs *JobFlowSteps)
 		// A bare terminal state is not enough to call this success: EMR reports
 		// plain TERMINATED even when the failure happened during bootstrap, so
 		// waitForClusterFinished's nil error cannot be trusted on its own.
+		//
+		// Reaching here does not mean no step ran. A short job can pass through
+		// RUNNING between two polls, so this also catches runs whose steps ran
+		// and failed. Only the reason code distinguishes them, which is why the
+		// retry decision keys on BOOTSTRAP_FAILURE alone.
 		code, message := clusterStateChangeReason(launchStatus)
 		switch {
 		case code == string(types.ClusterStateChangeReasonCodeAllStepsCompleted):
@@ -158,12 +167,12 @@ func runTransientAttempt(ctx context.Context, ec *EmrCluster, jfs *JobFlowSteps)
 			log.Infof("EMR cluster with ID [%s] is terminated successfully", jobflowID)
 			return nil, nil
 		case code != "" || message != "":
-			return launchStatus, launchFailureError(jobflowID, launchStatus)
+			return launchStatus, clusterFailureError(jobflowID, launchStatus)
 		default:
 			// No reason ever surfaced: the failure cannot be classified, so it
 			// must never be retried.
 			if settledErr == nil {
-				settledErr = fmt.Errorf("EMR cluster %s failed to launch with state %s and no state change reason",
+				settledErr = fmt.Errorf("EMR cluster %s failed with state %s and no state change reason",
 					jobflowID, launchStatus.State)
 			}
 			return nil, settledErr

--- a/src/transient_test.go
+++ b/src/transient_test.go
@@ -1,0 +1,406 @@
+//
+// Copyright (c) 2016-2026 Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+//
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/emr"
+	"github.com/aws/aws-sdk-go-v2/service/emr/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockEMRAPITransient scripts DescribeCluster responses so that multi-attempt
+// behaviour can be tested. attempts[i] is the ordered list of statuses returned
+// during the (i+1)th launch; the last entry repeats if more describes arrive than
+// were scripted, so extra polls do not panic the test.
+//
+// Every scripted status should be one the waiters resolve on immediately
+// (RUNNING, WAITING, TERMINATING, TERMINATED, TERMINATED_WITH_ERRORS) so the
+// tests never actually sleep on a poll interval.
+type mockEMRAPITransient struct {
+	attempts        [][]*types.ClusterStatus
+	runJobFlowCalls int
+	describeIdx     int
+	terminateCalls  int
+}
+
+func (m *mockEMRAPITransient) RunJobFlow(ctx context.Context, input *emr.RunJobFlowInput, optFns ...func(*emr.Options)) (*emr.RunJobFlowOutput, error) {
+	m.runJobFlowCalls++
+	m.describeIdx = 0
+	return &emr.RunJobFlowOutput{JobFlowId: aws.String("j-transient")}, nil
+}
+
+func (m *mockEMRAPITransient) DescribeCluster(ctx context.Context, input *emr.DescribeClusterInput, optFns ...func(*emr.Options)) (*emr.DescribeClusterOutput, error) {
+	script := m.attempts[m.runJobFlowCalls-1]
+	i := m.describeIdx
+	if i >= len(script) {
+		i = len(script) - 1
+	}
+	m.describeIdx++
+	return &emr.DescribeClusterOutput{Cluster: &types.Cluster{Status: script[i]}}, nil
+}
+
+func (m *mockEMRAPITransient) TerminateJobFlows(ctx context.Context, input *emr.TerminateJobFlowsInput, optFns ...func(*emr.Options)) (*emr.TerminateJobFlowsOutput, error) {
+	m.terminateCalls++
+	return &emr.TerminateJobFlowsOutput{}, nil
+}
+
+func (m *mockEMRAPITransient) AddJobFlowSteps(ctx context.Context, input *emr.AddJobFlowStepsInput, optFns ...func(*emr.Options)) (*emr.AddJobFlowStepsOutput, error) {
+	return nil, nil
+}
+
+func (m *mockEMRAPITransient) ListSteps(ctx context.Context, input *emr.ListStepsInput, optFns ...func(*emr.Options)) (*emr.ListStepsOutput, error) {
+	return nil, nil
+}
+
+func (m *mockEMRAPITransient) DescribeStep(ctx context.Context, input *emr.DescribeStepInput, optFns ...func(*emr.Options)) (*emr.DescribeStepOutput, error) {
+	return nil, nil
+}
+
+// statusWithReason builds a cluster status carrying a state change reason.
+func statusWithReason(state types.ClusterState, code types.ClusterStateChangeReasonCode, message string) *types.ClusterStatus {
+	return &types.ClusterStatus{
+		State: state,
+		StateChangeReason: &types.ClusterStateChangeReason{
+			Code:    code,
+			Message: aws.String(message),
+		},
+	}
+}
+
+// bareStatus builds a cluster status with no state change reason, as can be seen
+// at TERMINATING before the reason is populated.
+func bareStatus(state types.ClusterState) *types.ClusterStatus {
+	return &types.ClusterStatus{State: state}
+}
+
+// transientFixture wires a mock EMR client into both an EmrCluster and a
+// JobFlowSteps, using cluster fixture 2 because fixture 1 sets both a VPC subnet
+// and an availability zone, which GetJobFlowInput rejects.
+func transientFixture(attempts [][]*types.ClusterStatus) (*EmrCluster, *JobFlowSteps, *mockEMRAPITransient) {
+	svc := &mockEMRAPITransient{attempts: attempts}
+
+	clusterRecord, _ := CR.ParseClusterRecord([]byte(ClusterRecord2), nil, "")
+	playbookRecord, _ := CR.ParsePlaybookRecord([]byte(PlaybookRecord1), nil, "")
+
+	ec := &EmrCluster{Config: *clusterRecord, Svc: svc}
+	jfs := &JobFlowSteps{Config: *playbookRecord, IsBlocking: true, EmrSvc: svc}
+
+	return ec, jfs, svc
+}
+
+func TestRunTransientAttempt_Success(t *testing.T) {
+	assert := assert.New(t)
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			bareStatus(types.ClusterStateRunning),
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeAllStepsCompleted, "Steps completed"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.Nil(err)
+	assert.Nil(launchStatus)
+	assert.Equal(1, svc.runJobFlowCalls)
+	assert.Equal("j-transient", jfs.JobflowID)
+}
+
+func TestRunTransientAttempt_BootstrapFailure(t *testing.T) {
+	assert := assert.New(t)
+	// two describes: the launch-phase pre-check, then the settle branch's
+	// waitForClusterFinished
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	// the launch status comes back so the caller can decide whether to retry
+	assert.True(isBootstrapFailure(launchStatus))
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_ValidationErrorAtLaunch(t *testing.T) {
+	assert := assert.New(t)
+	// two describes: the launch-phase pre-check, then the settle branch's
+	// waitForClusterFinished
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeValidationError, "Subnet is invalid"),
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeValidationError, "Subnet is invalid"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "VALIDATION_ERROR")
+	assert.False(isBootstrapFailure(launchStatus))
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_StepFailure(t *testing.T) {
+	assert := assert.New(t)
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			bareStatus(types.ClusterStateRunning),
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeStepFailure, "Step failed"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "STEP_FAILURE")
+	// a job-phase failure must never look retryable: a step may already have run
+	assert.Nil(launchStatus)
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_JobPhaseTerminatedWithNonSuccessReason(t *testing.T) {
+	assert := assert.New(t)
+	// the cluster reached RUNNING, so a step may have started, and then died
+	// mid-step reporting plain TERMINATED with a reason other than
+	// ALL_STEPS_COMPLETED. waitForClusterFinished returns a nil error for any
+	// plain TERMINATED, so this must still produce an error — and a nil status,
+	// since a step may already have run.
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			bareStatus(types.ClusterStateRunning),
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeInstanceFailure, "Instance failure"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.Nil(launchStatus)
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_ShortJobRace(t *testing.T) {
+	assert := assert.New(t)
+	// the cluster passed through RUNNING between two polls, so the launch phase
+	// only ever sees it terminated — but the run actually succeeded
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeAllStepsCompleted, "Steps completed"),
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeAllStepsCompleted, "Steps completed"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.Nil(err)
+	assert.Nil(launchStatus)
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_TerminatingWithoutReason(t *testing.T) {
+	assert := assert.New(t)
+	// the launch phase catches the cluster at TERMINATING before the reason is
+	// populated; it must settle to the terminal state before classifying
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			bareStatus(types.ClusterStateTerminating),
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.True(isBootstrapFailure(launchStatus))
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_TerminatingReasonNeverPopulates(t *testing.T) {
+	assert := assert.New(t)
+	// an unclassifiable failure must not be mistaken for a bootstrap failure
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{bareStatus(types.ClusterStateTerminating), bareStatus(types.ClusterStateTerminatedWithErrors)},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.False(isBootstrapFailure(launchStatus))
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_LaunchTimeout(t *testing.T) {
+	assert := assert.New(t)
+	// A real 60-minute timeout cannot be exercised in a test. This simulates
+	// the same shape of outcome — waitForClusterReady returning a non-terminal
+	// status alongside a non-nil error — by handing it an already-cancelled
+	// context instead: the mock ignores ctx and keeps returning the scripted
+	// STARTING status, while the SDK waiter's inter-poll wait sees the
+	// cancellation and returns promptly, without ever actually sleeping.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{bareStatus(types.ClusterStateStarting)},
+	})
+
+	launchStatus, err := runTransientAttempt(ctx, ec, jfs)
+	assert.NotNil(err)
+	// a cluster that never resolved one way or the other must not be retried
+	assert.Nil(launchStatus)
+	assert.Equal(1, svc.runJobFlowCalls)
+	// the still-coming-up cluster must be torn down rather than left running
+	assert.Equal(1, svc.terminateCalls)
+}
+
+func TestRunTransientAttempt_TerminatedWithBootstrapFailureReason(t *testing.T) {
+	assert := assert.New(t)
+	// EMR can report plain TERMINATED, not TERMINATED_WITH_ERRORS, even when the
+	// cluster never came up because a bootstrap action failed. The launch phase
+	// never observed RUNNING here, so a bare TERMINATED must not be read as
+	// success.
+	// Two describes: the launch-phase pre-check, then the settle branch's
+	// waitForClusterFinished.
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.True(isBootstrapFailure(launchStatus))
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientAttempt_TerminatedWithStepFailureReason(t *testing.T) {
+	assert := assert.New(t)
+	// same shape as above but with a reason that must not be retried.
+	// Two describes: the launch-phase pre-check, then the settle branch's
+	// waitForClusterFinished.
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeStepFailure, "Step failed"),
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeStepFailure, "Step failed"),
+		},
+	})
+
+	launchStatus, err := runTransientAttempt(context.Background(), ec, jfs)
+	assert.NotNil(err)
+	assert.False(isBootstrapFailure(launchStatus))
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientJobFlow_RetriesBootstrapFailureThenSucceeds(t *testing.T) {
+	assert := assert.New(t)
+	// two describes per attempt: the launch-phase pre-check sees the
+	// already-terminal status, then the settle branch's waitForClusterFinished
+	// consumes a second before the reason can be classified
+	bootstrapFailure := []*types.ClusterStatus{
+		statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+		statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+	}
+	cleanRun := []*types.ClusterStatus{
+		bareStatus(types.ClusterStateRunning),
+		statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeAllStepsCompleted, "Steps completed"),
+	}
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{bootstrapFailure, cleanRun})
+
+	err := runTransientJobFlowWithJitter(context.Background(), ec, jfs, 1)
+	assert.Nil(err)
+	assert.Equal(2, svc.runJobFlowCalls)
+}
+
+func TestRunTransientJobFlow_GivesUpAfterThreeAttempts(t *testing.T) {
+	assert := assert.New(t)
+	// two describes per attempt, as above
+	bootstrapFailure := []*types.ClusterStatus{
+		statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+		statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeBootstrapFailure, "Bootstrap action returned a non-zero return code"),
+	}
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{bootstrapFailure, bootstrapFailure, bootstrapFailure})
+
+	err := runTransientJobFlowWithJitter(context.Background(), ec, jfs, 1)
+	assert.NotNil(err)
+	assert.Equal(
+		"could not start the cluster due to bootstrap failure after 3 attempts: code=BOOTSTRAP_FAILURE message=\"Bootstrap action returned a non-zero return code\"",
+		err.Error(),
+	)
+	assert.Equal(3, svc.runJobFlowCalls)
+}
+
+func TestRunTransientJobFlow_DoesNotRetryValidationError(t *testing.T) {
+	assert := assert.New(t)
+	// two describes: the launch-phase pre-check, then the settle branch's
+	// waitForClusterFinished
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeValidationError, "Subnet is invalid"),
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeValidationError, "Subnet is invalid"),
+		},
+	})
+
+	err := runTransientJobFlowWithJitter(context.Background(), ec, jfs, 1)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "VALIDATION_ERROR")
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientJobFlow_DoesNotRetryStepFailure(t *testing.T) {
+	assert := assert.New(t)
+	// the safety case: a step may already have run, so the playbook must not be
+	// re-submitted. Two describes: launch-phase pre-check observes RUNNING (up),
+	// then the job-phase waitForClusterFinished observes the step failure.
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			bareStatus(types.ClusterStateRunning),
+			statusWithReason(types.ClusterStateTerminatedWithErrors, types.ClusterStateChangeReasonCodeStepFailure, "Step failed"),
+		},
+	})
+
+	err := runTransientJobFlowWithJitter(context.Background(), ec, jfs, 1)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "STEP_FAILURE")
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientJobFlow_DoesNotRetryUnclassifiableFailure(t *testing.T) {
+	assert := assert.New(t)
+	// two describes: launch-phase pre-check sees TERMINATING (not yet reasoned),
+	// then the settle branch's waitForClusterFinished sees the terminal state with
+	// no reason ever populated.
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{bareStatus(types.ClusterStateTerminating), bareStatus(types.ClusterStateTerminatedWithErrors)},
+	})
+
+	err := runTransientJobFlowWithJitter(context.Background(), ec, jfs, 1)
+	assert.NotNil(err)
+	assert.Equal(1, svc.runJobFlowCalls)
+}
+
+func TestRunTransientJobFlow_SucceedsFirstTime(t *testing.T) {
+	assert := assert.New(t)
+	// two describes: launch-phase pre-check observes RUNNING (up), then the
+	// job-phase waitForClusterFinished observes clean termination.
+	ec, jfs, svc := transientFixture([][]*types.ClusterStatus{
+		{
+			bareStatus(types.ClusterStateRunning),
+			statusWithReason(types.ClusterStateTerminated, types.ClusterStateChangeReasonCodeAllStepsCompleted, "Steps completed"),
+		},
+	})
+
+	err := runTransientJobFlowWithJitter(context.Background(), ec, jfs, 1)
+	assert.Nil(err)
+	assert.Equal(1, svc.runJobFlowCalls)
+}


### PR DESCRIPTION
Jira ref: [CSTMR-2114](https://snplow.atlassian.net/browse/CSTMR-2114)

Transient runs failed outright on BOOTSTRAP_FAILURE, which is almost always transient and succeeds on the next scheduled run. `up` has retried these for some time; `run-transient` never did.

This makes transient error handling consistent with the persistent path. Both now share one bootstrap-failure predicate, observe the launch phase with ClusterRunningWaiter, and decide outcomes from StateChangeReason rather than terminal state. That last point matters: EMR reports a failed step as plain TERMINATED with an empty reason code, so judging by state alone reported failed runs as successes.

A transient run is now watched as two phases, launch (60 min) and job (14 days), rather than a single 14-day terminate wait. Only BOOTSTRAP_FAILURE is retried, up to three launches: bootstrap actions run before any step, so no step can have run and re-submitting the playbook is safe.

[CSTMR-2114]: https://snplow.atlassian.net/browse/CSTMR-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ