### PR TITLE
Add Snowman CI hook to cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -173,15 +173,3 @@ jobs:
           echo ""
           echo "Version \`${{ github.ref_name }}\` is a \`-dev\` tag; Snowman intentionally skips the rollout per the SRE rollout policy. Tests link: ${{ steps.snowman-tests.outputs.workflow-url }}"
         } >> "$GITHUB_STEP_SUMMARY"
-
-    - name: Append Snowman link to GitHub Release notes
-      if: ${{ startsWith(github.ref, 'refs/tags/') && steps.snowman-tests.outputs.workflow-conclusion == 'success' && steps.tag.outputs.is_dev == 'false' }}
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ github.ref_name }}
-        append_body: true
-        body: |
-
-          ---
-          🚀 **Snowman tests + rollout:** ${{ steps.snowman-tests.outputs.workflow-url }}
-          Track the staged rollout in `#pipeline-rollouts` on Slack (~7h end-to-end, with approval gates between cohorts).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,3 +71,117 @@ jobs:
 
     - name: Publish docker image
       run: make docker-cross-build-publish
+
+  # Post-release QA validation via the Snowman framework.
+  # Guide: Quality Engineering > Guides > "Snowman - CI Hook Guide" (Notion).
+  #
+  # Async model (QA-831 / QA-832): this job waits for the TESTS only (~60-90 min).
+  # Any rollout runs asynchronously on Snowman's side and is an SRE/Data-CAP
+  # concern, so caller CI is red only when tests fail.
+  snowman-tests:
+    # The guide gates on `github.event.repository.private == true` to skip the
+    # public mirror of a private release repo. dataflow-runner has no private
+    # mirror — it is public-only — so that condition would be permanently false
+    # and this job would never run. Gating on the canonical repository instead
+    # keeps the intent (forks must not dispatch into Snowman) while letting the
+    # job actually fire here.
+    if: |
+      github.repository == 'snowplow/dataflow-runner' &&
+      startsWith(github.ref, 'refs/tags/') && (
+        !contains(github.ref_name, '-') ||
+        contains(github.ref_name, '-rc') ||
+        contains(github.ref_name, '-dev')
+      )
+    name: Run Snowman Tests and Rollout
+    runs-on: ubuntu-latest
+    # dataflow-runner builds and publishes the image in a single `release` job,
+    # rather than the separate `deploy_to_docker` job the guide's example names.
+    needs: release
+    strategy:
+      matrix:
+        component:
+          - dataflow_runner
+        # Component tests only, deliberately. dataflow-runner is a CLI binary
+        # invoked by one stack, so it has no multi-component interaction story a
+        # composite would add. The two other suites that stand up the shredder
+        # (components/rdb_loader, composites/collector_warehouse_pipelines) do
+        # NOT pin dataflow_runner_version, so dispatching a release at them would
+        # exercise whatever DS4 defaults to rather than the version being
+        # released — green, and meaningless.
+        test_directory:
+          - dataflow_runner
+
+    steps:
+    - name: Detect tag type (for skip-rollout vs link path)
+      id: tag
+      run: |
+        v="${{ github.ref_name }}"
+        if [[ "$v" =~ -dev ]] || [[ "$v" =~ dev[0-9]+ ]]; then
+          echo "is_dev=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "is_dev=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Run Snowman QA Tests
+      id: snowman-tests
+      uses: the-actions-org/workflow-dispatch@v4
+      with:
+        # The workflow's `name:`, not its filename — the filename form works
+        # today but breaks silently if either side is renamed.
+        workflow: Trigger Snowman Tests
+        repo: snowplow-devops/snowman
+        # Snowman has a "Verify dispatched from main" guard that fails fast on
+        # any other ref.
+        ref: refs/heads/main
+        token: ${{ secrets.GLOBAL_QA_FRAMEWORK_PAT }}
+        inputs: >-
+          {
+            "test_directory": "${{ matrix.test_directory }}",
+            "component": "${{ matrix.component }}",
+            "version": "${{ github.ref_name }}",
+            "dry_run": false,
+            "token": "${{ secrets.GLOBAL_QA_FRAMEWORK_PAT }}"
+          }
+        wait-for-completion: true
+        # Tests only (~60-90 min real-world plus headroom). Never raise this to
+        # cover a rollout: ubuntu-latest runners are capped at 6h by GitHub and
+        # the rollout takes ~7h.
+        wait-for-completion-timeout: 120m
+        display-workflow-run-url: true
+
+    - name: Publish Snowman link to Actions summary
+      if: ${{ steps.snowman-tests.outputs.workflow-conclusion == 'success' && steps.tag.outputs.is_dev == 'false' }}
+      run: |
+        {
+          echo "### 🚀 Snowman tests + rollout dispatched"
+          echo ""
+          echo "| | |"
+          echo "|---|---|"
+          echo "| **Component** | \`${{ matrix.component }}\` |"
+          echo "| **Version**   | \`${{ github.ref_name }}\` |"
+          echo "| **Tests + rollout link** | ${{ steps.snowman-tests.outputs.workflow-url }} |"
+          echo "| **Slack channel** | \`#pipeline-rollouts\` |"
+          echo ""
+          echo "_The rollout itself runs async (~7h). Open the link above and check the run's job summary for a direct rollout URL, or watch \`#pipeline-rollouts\` for cohort progress._"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Note no-rollout (dev tag) in Actions summary
+      if: ${{ steps.snowman-tests.outputs.workflow-conclusion == 'success' && steps.tag.outputs.is_dev == 'true' }}
+      run: |
+        {
+          echo "### ℹ️ Snowman tests passed — no rollout dispatched"
+          echo ""
+          echo "Version \`${{ github.ref_name }}\` is a \`-dev\` tag; Snowman intentionally skips the rollout per the SRE rollout policy. Tests link: ${{ steps.snowman-tests.outputs.workflow-url }}"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Append Snowman link to GitHub Release notes
+      if: ${{ startsWith(github.ref, 'refs/tags/') && steps.snowman-tests.outputs.workflow-conclusion == 'success' && steps.tag.outputs.is_dev == 'false' }}
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.ref_name }}
+        append_body: true
+        body: |
+
+          ---
+          🚀 **Snowman tests + rollout:** ${{ steps.snowman-tests.outputs.workflow-url }}
+          Track the staged rollout in `#pipeline-rollouts` on Slack (~7h end-to-end, with approval gates between cohorts).


### PR DESCRIPTION
## What

Adds the `snowman-tests` job to `cd.yml`, per the [Snowman CI Hook Guide](https://www.notion.so/keep-in-the-snow/Snowman-CI-Hook-Guide-20007af295a28063946ef578e4696dbe).

After a tag release it dispatches the Snowman QA framework and waits on the **tests only** (~60–90 min). Any rollout runs asynchronously on Snowman's side for up to ~7h and is an SRE / Data CAP concern, so this job goes red only when tests fail.

## Why now

Dataflow Runner has component coverage in Snowman as of [snowplow-devops/snowman#847](https://github.com/snowplow-devops/snowman/pull/847): six automated behaviours over the EMR path — cluster provisioning at the requested `ReleaseLabel`, playbook step order and count, transient termination via `ALL_STEPS_COMPLETED`, transformed output in S3 plus CloudWatch metrics, Avro config-schema acceptance, and bootstrap-failure reporting. That PR also registers `dataflow_runner` in `component_version_key.sh` and `COMPONENT_STACKS`, so a dispatched rollout resolves to the `aws_rdb_shredder` stack and updates its `dataflow_runner_version` key.

## Deviations from the guide's example

**`needs: release`, not `needs: deploy_to_docker`.** Dataflow Runner builds and publishes its image in a single `release` job.

**The gate is `github.repository == 'snowplow/dataflow-runner'`, not `github.event.repository.private == true`.**

This is the one worth scrutinising. The guide's gate exists to skip the *public mirror* of a private release repo. Dataflow Runner has no private mirror — `snowplow/dataflow-runner` is public and `snowplow/dataflow-runner-private` does not exist — so `repository.private == true` would be **permanently false** and the job would never run at all. Gating on the canonical repository preserves the intent, that a fork must never dispatch into Snowman, while letting the job actually fire here. Worth revisiting if a private mirror is ever introduced.

**`#pipeline-rollouts`, not `#automated-rollouts`.** The latter is deprecated since QA-1114; pipeline and data-processing components post to `#pipeline-rollouts`. The guide is internally inconsistent here — its summary table already says `#pipeline-rollouts` while its prose and release-notes snippet still name the old channel.

## Component tests only — no composites

The matrix is `component: dataflow_runner` / `test_directory: dataflow_runner`, deliberately. Rationale recorded on [QA-994](https://snplow.atlassian.net/browse/QA-994), in short:

Dataflow Runner is a CLI binary that orchestrates a single EMR cluster on behalf of one stack, so there is no multi-component interaction for a composite to exercise. The "RDB Transformer Batch + RDB Loader" composition is the shredder's own playbook, which Dataflow Runner runs as steps on one cluster — not a pipeline of independently deployed components.

Two other Snowman suites do stand up the shredder, `components/rdb_loader` and `composites/collector_warehouse_pipelines`, but **neither pins `dataflow_runner_version`**. Both ride the DS4 provider default, so dispatching a release at them would come back green having exercised a different binary than the one released. Making them meaningful would mean plumbing the version through both modules first, for coverage the component suite already provides.

## Behaviour by tag type

Handled on the Snowman side; this job's only local branch is the summary text.

| Tag | Result |
| --- | --- |
| `X.Y.Z` | tests run, full rollout chain dispatched |
| `X.Y.Z-rcN` | tests run, canary-only rollout (pre-release lockdown) |
| `X.Y.Z-devN` | tests run, **no rollout** — the job stays green with a "no rollout (dev tag)" summary |

## Verification

`actionlint` reports the **same 6 findings before and after** this change, all in the pre-existing `release` job (deprecated `set-output`, older action runners). No new issues introduced. The workflow parses as valid YAML, and the new job starts at line 81, clear of every finding.

`wait-for-completion-timeout` is 120m, covering tests plus headroom. It is deliberately not raised to cover the rollout: `ubuntu-latest` runners are capped at 6h by GitHub Actions and the rollout takes ~7h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QA-994]: https://snplow.atlassian.net/browse/QA-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ